### PR TITLE
remove fat arrow syntax

### DIFF
--- a/modules/base/progress.js
+++ b/modules/base/progress.js
@@ -1,5 +1,5 @@
 class ProgressReport {
-  validate = options => {
+  validate(options) {
     const { done, data } = options
     if (typeof done !== 'boolean')
       throw new Error('property done of progress report must be a boolean')


### PR DESCRIPTION
support node v8 by removing es6 fat arrow syntax